### PR TITLE
feat: Update elm-format version

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,4 +7,4 @@
   files: \.(elm)$
   args: []
   minimum_pre_commit_version: 0.6.7
-  additional_dependencies: ["elm-format@0.8.2"]
+  additional_dependencies: ["elm-format@0.8.7"]


### PR DESCRIPTION
- Current behavior 
  - pre-commit is failed when code is formatted with the newer version of `elm-format@0.8.7` [1]
- Reason to be failed 
  - This pre-commit additional dependency is `elm-format@0.8.2`  [2]

[1]: https://github.com/avh4/elm-format/tags
[2]:  https://github.com/a-ibs/pre-commit-mirrors-elm-format/blob/2feade650cfaec8e54f4980e3613a9a90d948597/.pre-commit-hooks.yaml#L10